### PR TITLE
fix: do not require code owner review for deploy PRs

### DIFF
--- a/templates/.github/CODEOWNERS.tpl
+++ b/templates/.github/CODEOWNERS.tpl
@@ -4,3 +4,5 @@
 # See https://help.github.com/articles/about-codeowners/
 # Default ownership -- owning team owns everything by default
 * {{ stencil.Arg "githubOwner" }}
+# Do not require CODEOWNERS review for deploy PRs
+helm/*/values-*.yaml


### PR DESCRIPTION
Codeowner requires can potentially block automated deploy workflows by requiring code owner approval.  This change will remove that requirement